### PR TITLE
qemu 6.2.0 pinning

### DIFF
--- a/hw/core/machine.c
+++ b/hw/core/machine.c
@@ -764,6 +764,40 @@ static void machine_set_smp(Object *obj, Visitor *v, const char *name,
     smp_parse(ms, config, errp);
 }
 
+static int vcpu_parse(MachineState *ms, QemuOpts *opts)
+{
+    MachineClass *mc = MACHINE_GET_CLASS(ms);
+
+    if (opts) {
+        unsigned vcpu = qemu_opt_get_number(opts, "vcpunum", 0);
+        unsigned affinity = qemu_opt_get_number(opts,"affinity", 0);
+
+        /* Previously, smp_parse() was invoked before vcpu_parse().
+         * As of 6.1, this is not the case anymore; by looking statically at the
+         * code, it's not clear at which point smp_parse() is invoked; a remediation
+         * has been attempted (see `v6.1.0-pinning-check` branch), but it's not
+         * correct.
+         * The project is officially discontinued, so we just disable the check
+         * and warn the user (on the README).
+         */
+        // if (vcpu < ms->smp.max_cpus) {
+            if (mc->vcpu_affinity[vcpu] == -1) {
+                mc->vcpu_affinity[vcpu] = affinity;
+            }
+            else {
+                error_report("Duplicate affinity statement for vcpu %d\n", vcpu);
+                return -1;
+            }
+        // }
+        // else {
+        //     error_report("VCPU %d exceeds maximum allowed (%d)\n", vcpu, ms->smp.max_cpus);
+        //     return -1;
+        // }
+    }
+
+    return 0;
+}
+
 static void machine_class_init(ObjectClass *oc, void *data)
 {
     MachineClass *mc = MACHINE_CLASS(oc);
@@ -771,6 +805,10 @@ static void machine_class_init(ObjectClass *oc, void *data)
     /* Default 128 MB as guest ram size */
     mc->default_ram_size = 128 * MiB;
     mc->rom_file_has_mr = true;
+    mc->vcpu_parse = vcpu_parse;
+
+    for (int i = 0; i < CPU_SETSIZE; i++)
+        mc->vcpu_affinity[i] = -1;
 
     /* numa node memory size aligned on 8MB by default.
      * On Linux, each node's border has to be 8MB aligned

--- a/include/hw/boards.h
+++ b/include/hw/boards.h
@@ -35,6 +35,7 @@ void machine_set_cpu_numa_node(MachineState *machine,
                                const CpuInstanceProperties *props,
                                Error **errp);
 void smp_parse(MachineState *ms, SMPConfiguration *config, Error **errp);
+void parse_vcpu_opts(MachineState *ms);
 
 /**
  * machine_class_allow_dynamic_sysbus_dev: Add type to list of valid devices
@@ -231,7 +232,6 @@ struct MachineClass {
     void (*reset)(MachineState *state);
     void (*wakeup)(MachineState *state);
     int (*kvm_type)(MachineState *machine, const char *arg);
-    int (*vcpu_parse)(MachineState *ms, QemuOpts *opts);
 
     BlockInterfaceType block_default_type;
     int units_per_default_bus;

--- a/include/hw/boards.h
+++ b/include/hw/boards.h
@@ -231,12 +231,14 @@ struct MachineClass {
     void (*reset)(MachineState *state);
     void (*wakeup)(MachineState *state);
     int (*kvm_type)(MachineState *machine, const char *arg);
+    int (*vcpu_parse)(MachineState *ms, QemuOpts *opts);
 
     BlockInterfaceType block_default_type;
     int units_per_default_bus;
     int max_cpus;
     int min_cpus;
     int default_cpus;
+    int vcpu_affinity[CPU_SETSIZE];
     unsigned int no_serial:1,
         no_parallel:1,
         no_floppy:1,

--- a/qemu-options.hx
+++ b/qemu-options.hx
@@ -248,6 +248,16 @@ SRST
     over threads. Since 6.2 the preference is cores over sockets over threads.
 ERST
 
+DEF("vcpu", HAS_ARG, QEMU_OPTION_vcpu,
+    "-vcpu [vcpunum=]n[,affinity=affinity]\n"
+    "-vcpu [vcpunum=]n[,affinity=affinity]\n", QEMU_ARCH_ALL)
+SRST
+@item -vcpu [vcpunum=]n[,affinity=affinity]
+@itemx -vcpu [vcpunum=]n[,affinity=affinity]
+@findex -vcpu
+VCPU Affinity. If specified, specify for all the CPUs.
+ERST
+
 DEF("numa", HAS_ARG, QEMU_OPTION_numa,
     "-numa node[,mem=size][,cpus=firstcpu[-lastcpu]][,nodeid=node][,initiator=node]\n"
     "-numa node[,memdev=id][,cpus=firstcpu[-lastcpu]][,nodeid=node][,initiator=node]\n"

--- a/qemu-options.hx
+++ b/qemu-options.hx
@@ -250,12 +250,12 @@ ERST
 
 DEF("vcpu", HAS_ARG, QEMU_OPTION_vcpu,
     "-vcpu [vcpunum=]n[,affinity=affinity]\n"
-    "-vcpu [vcpunum=]n[,affinity=affinity]\n", QEMU_ARCH_ALL)
+    "                the index of the vCPU to pin\n"
+    "                affinity= the host CPU index to pin to\n",
+        QEMU_ARCH_ALL)
 SRST
-@item -vcpu [vcpunum=]n[,affinity=affinity]
-@itemx -vcpu [vcpunum=]n[,affinity=affinity]
-@findex -vcpu
-VCPU Affinity. If specified, specify for all the CPUs.
+``-vcpu [vcpunum=]n[,affinity=affinity]``
+    VCPU Affinity. If specified, specify for all the CPUs.
 ERST
 
 DEF("numa", HAS_ARG, QEMU_OPTION_numa,

--- a/softmmu/cpus.c
+++ b/softmmu/cpus.c
@@ -613,7 +613,7 @@ void qemu_init_vcpu(CPUState *cpu)
     cpu_set_t cpuset;
     MachineState *ms = MACHINE(qdev_get_machine());
     MachineClass *mc = MACHINE_GET_CLASS(ms);
-    unsigned vcpu = mc->vcpu_affinity[cpu->cpu_index];
+    unsigned affinity = mc->vcpu_affinity[cpu->cpu_index];
 
     cpu->nr_cores = ms->smp.cores;
     cpu->nr_threads =  ms->smp.threads;
@@ -632,9 +632,9 @@ void qemu_init_vcpu(CPUState *cpu)
     g_assert(cpus_accel != NULL && cpus_accel->create_vcpu_thread != NULL);
     cpus_accel->create_vcpu_thread(cpu);
 
-    if (vcpu != -1) {
+    if (affinity != -1) {
         CPU_ZERO(&cpuset);
-        CPU_SET(vcpu, &cpuset);
+        CPU_SET(affinity, &cpuset);
         pthread_setaffinity_np((cpu->thread)->thread, sizeof(cpu_set_t), &cpuset);
     }
 

--- a/softmmu/cpus.c
+++ b/softmmu/cpus.c
@@ -610,7 +610,10 @@ void cpus_register_accel(const AccelOpsClass *ops)
 
 void qemu_init_vcpu(CPUState *cpu)
 {
+    cpu_set_t cpuset;
     MachineState *ms = MACHINE(qdev_get_machine());
+    MachineClass *mc = MACHINE_GET_CLASS(ms);
+    unsigned vcpu = mc->vcpu_affinity[cpu->cpu_index];
 
     cpu->nr_cores = ms->smp.cores;
     cpu->nr_threads =  ms->smp.threads;
@@ -628,6 +631,12 @@ void qemu_init_vcpu(CPUState *cpu)
     /* accelerators all implement the AccelOpsClass */
     g_assert(cpus_accel != NULL && cpus_accel->create_vcpu_thread != NULL);
     cpus_accel->create_vcpu_thread(cpu);
+
+    if (vcpu != -1) {
+        CPU_ZERO(&cpuset);
+        CPU_SET(vcpu, &cpuset);
+        pthread_setaffinity_np((cpu->thread)->thread, sizeof(cpu_set_t), &cpuset);
+    }
 
     while (!cpu->created) {
         qemu_cond_wait(&qemu_cpu_cond, &qemu_global_mutex);

--- a/softmmu/vl.c
+++ b/softmmu/vl.c
@@ -1166,14 +1166,6 @@ static inline bool nonempty_str(const char *str)
     return str && *str;
 }
 
-static int vl_parse_vcpu(void *opaque, QemuOpts *opts, Error **errp)
-{
-    MachineState *ms = opaque;
-    MachineClass *mc = MACHINE_GET_CLASS(ms);
-
-    return mc->vcpu_parse(ms, opts);
-}
-
 static int parse_fw_cfg(void *opaque, QemuOpts *opts, Error **errp)
 {
     gchar *buf;
@@ -2189,10 +2181,6 @@ static void qemu_create_machine(QDict *qdict)
 
     if (machine_class->hw_version) {
         qemu_set_hw_version(machine_class->hw_version);
-    }
-
-    if (qemu_opts_foreach(qemu_find_opts("vcpu-opts"), vl_parse_vcpu, current_machine, NULL)) {
-        exit(1);
     }
 
     /*
@@ -3750,6 +3738,7 @@ void qemu_init(int argc, char **argv, char **envp)
     qemu_apply_legacy_machine_options(machine_opts_dict);
     qemu_apply_machine_options(machine_opts_dict);
     qobject_unref(machine_opts_dict);
+    parse_vcpu_opts(current_machine);
     phase_advance(PHASE_MACHINE_CREATED);
 
     /*

--- a/softmmu/vl.c
+++ b/softmmu/vl.c
@@ -711,6 +711,22 @@ static void configure_blockdev(BlockdevOptionsQueue *bdo_queue,
 
 }
 
+static QemuOptsList qemu_vcpu_opts = {
+    .name = "vcpu-opts",
+    .implied_opt_name = "vcpunum",
+    .head = QTAILQ_HEAD_INITIALIZER(qemu_vcpu_opts.head),
+    .desc = {
+        {
+            .name = "vcpunum",
+            .type = QEMU_OPT_NUMBER,
+        }, {
+            .name = "affinity",
+            .type = QEMU_OPT_NUMBER,
+        },
+        { /*End of list */ }
+    },
+};
+
 static QemuOptsList qemu_smp_opts = {
     .name = "smp-opts",
     .implied_opt_name = "cpus",
@@ -1148,6 +1164,14 @@ static void parse_display(const char *p)
 static inline bool nonempty_str(const char *str)
 {
     return str && *str;
+}
+
+static int vl_parse_vcpu(void *opaque, QemuOpts *opts, Error **errp)
+{
+    MachineState *ms = opaque;
+    MachineClass *mc = MACHINE_GET_CLASS(ms);
+
+    return mc->vcpu_parse(ms, opts);
 }
 
 static int parse_fw_cfg(void *opaque, QemuOpts *opts, Error **errp)
@@ -2167,6 +2191,10 @@ static void qemu_create_machine(QDict *qdict)
         qemu_set_hw_version(machine_class->hw_version);
     }
 
+    if (qemu_opts_foreach(qemu_find_opts("vcpu-opts"), vl_parse_vcpu, current_machine, NULL)) {
+        exit(1);
+    }
+
     /*
      * Get the default machine options from the machine if it is not already
      * specified either by the configuration file or by the command line.
@@ -2792,6 +2820,7 @@ void qemu_init(int argc, char **argv, char **envp)
     qemu_add_opts(&qemu_accel_opts);
     qemu_add_opts(&qemu_mem_opts);
     qemu_add_opts(&qemu_smp_opts);
+    qemu_add_opts(&qemu_vcpu_opts);
     qemu_add_opts(&qemu_boot_opts);
     qemu_add_opts(&qemu_add_fd_opts);
     qemu_add_opts(&qemu_object_opts);
@@ -3410,6 +3439,12 @@ void qemu_init(int argc, char **argv, char **envp)
             case QEMU_OPTION_smp:
                 machine_parse_property_opt(qemu_find_opts("smp-opts"),
                                            "smp", optarg);
+                break;
+            case QEMU_OPTION_vcpu:
+                if (!qemu_opts_parse_noisily(qemu_find_opts("vcpu-opts"),
+                                             optarg, true)) {
+                    exit(1);
+                }
                 break;
             case QEMU_OPTION_vnc:
                 vnc_parse(optarg);

--- a/util/qemu-thread-posix.c
+++ b/util/qemu-thread-posix.c
@@ -523,6 +523,10 @@ static void *qemu_thread_start(void *args)
     void *arg = qemu_thread_args->arg;
     void *r;
 
+#ifdef PRINT_THREADS_IDS
+    qemu_log(" -> PID %d\n", gettid());
+#endif
+
     /* Attempt to set the threads name; note that this is for debug, so
      * we're not going to fail if we can't set it.
      */
@@ -592,6 +596,10 @@ void qemu_thread_create(QemuThread *thread, const char *name,
     qemu_thread_args->name = g_strdup(name);
     qemu_thread_args->start_routine = start_routine;
     qemu_thread_args->arg = arg;
+
+#ifdef PRINT_THREADS_IDS
+    qemu_log("Creating thread '%s'", name);
+#endif
 
     err = pthread_create(&thread->thread, &attr,
                          qemu_thread_start, qemu_thread_args);


### PR DESCRIPTION
github will show this as a mess without a v6.2.0 branch as a base, so [click here to see a sane diff](https://github.com/qemu/qemu/compare/v6.2.0...arcnmx:pinning-arc)

basically I just rebased the original commit onto 6.2.0 (which I first tested individually fwiw) and then addressed the comment (the smp-opts get set indirectly via `object_set_properties_from_keyval` in `qemu_apply_machine_options`)

feel free to ignore since I know this isn't maintained, but I figured I'd share a solution just in case since I recently updated to 6.2.0